### PR TITLE
template for UVCoupling object and associated functionality

### DIFF
--- a/hera_coupling/__init__.py
+++ b/hera_coupling/__init__.py
@@ -1,0 +1,2 @@
+from . import io
+from .uvcoupling import UVCoupling

--- a/hera_coupling/uvcoupling.py
+++ b/hera_coupling/uvcoupling.py
@@ -1,0 +1,136 @@
+
+import numpy as np
+
+
+class UVCoupling:
+	"""
+	A data format for semi-analytic,
+	interferometer mutual coupling parameters.
+	"""        
+	def __init__(self, X_mat, antpos, inverted=False):
+		"""
+		Parameters
+		----------
+		X_mat : ndarray
+			Complex coupling parameter matrix, of shape
+			(Npol, Nants, Nants, Ntimes, Nfreqs)
+		antpos : dict
+			Antenna position dictionary, keys
+			are ant numbers, values are antenna
+			positions in ENU [meters]. Assumed
+			that the ordering in antpos matches
+			the ordering of X_mat Nants dimension.
+        inverted : bool, optional
+            Whether the X_mat has been inverted or not.
+            Default = False.
+		"""
+		self.X_mat = X_mat
+		self.antpos = antpos
+		self.ants = list(self.antpos.keys())
+		self.Nants = len(self.ants)
+		self.Npol, _Nants, _, self.Ntimes, self.Nfreqs = X_mat.shape
+		assert self.Nants == _Nants
+		assert self.Npol == 1, "Currently only supports single-pol"
+        self.inverted = inverted
+
+        # pre-compute Identity matrix
+        self.I = np.zeros(1, self.Nants, self.Nants, 1, 1)
+        self.I[:, range(self.Nants), range(self.Nants)] += 1
+
+	def apply_to_data(self, data):
+		raise NotImplementedError
+
+	def to_hera_sim(self):
+		raise NotImplementedError
+
+	def write_npz(self):
+		raise NotImplementedError
+
+    def read_npz(self):
+        raise NotImplementedError
+
+    def invert(self, rcond=1e-15):
+        raise NotImplementedError
+        X_inv = np.zeros_like(self.X_mat)
+        for p in range(self.Npols):
+            for t in range(self.Ntimes):
+                for f in range(self.Nfreqs):
+                    X_inv[p, :, :, t, f] = np.linalg.pinv(self.X_mat[p, :, :, t, f], rcond=rcond)
+        return UVCoupling(X_inv, self.antpos, inverted=True)
+
+	@classmethod
+	def from_npz(cls, ):
+		raise NotImplementedError
+		return cls(X_mat, antpos, **kwargs)
+
+
+class CouplingInflate:
+    """
+    Take a redundantly-compressed coupling parameter vector
+    and inflate it to an Nants x Nants coupling matrix,
+    with antenna ordering set by antpos.
+    """
+    def __init__(self, coupling_vecs, antpos, redtol=1.0):
+        """
+        Parameters
+        ----------
+        coupling_vecs : ndarray
+            Coupling term baseline vectors,
+            shape (Nterms, 3) in ENU [meters]
+        antpos : dict
+            Antenna position dictionary
+        redtol : float
+            Redundancy tolerance [meters]
+        """
+        self.coupling_vecs = coupling_vecs
+        self.antpos = antpos
+        self.ants = list(antpos.keys())
+        Nants = len(antpos)
+        self.redtol = redtol
+        self.shape = (Nants, Nants)
+
+        idx = np.zeros(self.shape, dtype=np.int64)
+        zeros = np.zeros(self.shape, dtype=np.bool)
+
+        # iterate over antenna-pairs
+        for i, ant1 in enumerate(self.ants):
+            for j, ant2 in enumerate(self.ants):
+                vec = antpos[ant1] - antpos[ant2]
+                norm = np.linalg.norm(vecs - vec, axis=1)
+                match = np.isclose(norm, 0, atol=redtol)
+                if norm.any():
+                    idx[i, j] = np.where(norm)[0]
+                else:
+                    zeros[i, j] = True
+
+        self.idx = idx.ravel()
+        self.zeros = zeros.ravel()
+
+    def __call__(self, params):
+        # params = (Npol, Nvec, Ntimes, Nfreqs)
+        shape = params.shape[:2] + self.shape + params.shape[-2:]
+
+        # params = (Npol, Nant^2, Ntimes, Nfreqs)
+        params = params[:, :, self.idx]
+
+        # zero-out missing vectors
+        params[:, :, self.zeros] = 0.0
+
+        # params = (Npol, Nant, Nant, Ntimes, Nfreqs)
+        params = params.reshape(shape)
+
+        return params
+
+
+class RedCouplingAvg:
+    """
+    Take an Nants x Nants coupling matrix and compress
+    down to redundant coupling vectors.
+    """
+    def __init__(self):
+        raise NotImplementedError
+
+    def __call__(self, params):
+        pass
+
+


### PR DESCRIPTION
Here is a first pass at outlining a coupling in-memory object for our semi-analytic model of mutual coupling.
Here is the rough goal of this PR:

• Add `UVCoupling` object for handling coupling parameters, with read/write to `.npz`, and (some) interoperability with `hera_sim`(?)
• Add `CouplingInflate` and `CouplingRedAvg` objects for inflating / compressing coupling parameters to redundant baselines.
• Add `apply_coupling` function to apply coupling parameters to `UVData`, `ndarray` and `hera_cal.DataContainer`
• Add `invert_coupling` function to apply inverse coupling parameters to ...
• Add `sympy` unit-test for making sure the `apply_coupling` and `invert_coupling` is actually doing this as our math would expect.

Disclaimer: This is a work in progress, all object names and structures are subject to change.

Here is an appendix for posterity on the parameterization and how we will "apply" the coupling to the visibility data.
- See [Kern+2019](https://arxiv.org/abs/1909.11732), [Josaitis+2022](https://academic.oup.com/mnras/article/514/2/1804/6564718), [Rath+2024](https://arxiv.org/abs/2406.08549) for the underlying mathematics of a radiative mutual coupling model operating as coupling coefficients of neighboring antenna voltages.
- Here is a high-level summary of the above: The $N_{\rm ants}\times N_{\rm ants}$ visibility matrix ($V$) formed by taking the outer product of the antenna voltage vector ($v$) is given as

```math
\large
V = \langle v v^\dagger\rangle
```

Our semi-analytic coupling model says that all antennas mix their intrinsically measured antenna voltage with all other antennas, to form the corrupted antenna voltage. For antenna 1, for example, this looks like

```math
\tilde{v}_1 = v_1 + \epsilon_{1,1}v_1 + \epsilon_{1,2}v_2 +  \epsilon_{1,3}v_3 + \ldots = v_1 + \sum_q\epsilon_{1,q}v_q,
```

where $\epsilon_{pq}$ is the coefficient that maps $v_q$ into $v_p$ (note the ordering!).

If we write this as a matrix

```math
X = \left[\begin{array}{cccc}
\epsilon_{1,1} & \epsilon_{1,2} & \ldots & \epsilon_{1,n} \\
\epsilon_{2,1} & \epsilon_{2,2} & & \vdots \\
\vdots & & \ddots & \\
\epsilon_{n,1} & \ldots & & \epsilon_{n,n}
 \end{array}
\right]
```

then the coupled voltage vector is

```math
\tilde{v} = v + Xv,
```

or

```math
\tilde{v} = Ev
```

with 

```math
E = I + X.
```

Note that while $V$ is hermitian, $X$ is in general not! Taking the outer-product yields the coupled visibility matrix

```math
\tilde{V} = \langle \tilde{v}\tilde{v}^\dagger\rangle = EVE^\dagger
```

We can easily show that this expands as

```math
\tilde{{V}} = {V} + \left[{X}{V} + {V}{X}^\dagger\right] + {X}{V}{X}^\dagger
```

where note that the first three terms on the RHS of the above equality were referred to collectively as $V^{(1)}$ by Josaitis+22 and Rath+24.

We can decompose each coupling coefficient, $\epsilon_{p,q}$, into a terms defined by the antenna (as is done in Josaitis+22), but these are highly uncertain.
Instead, we will opt to keep them as complex quantities for generality. Nonetheless, we can break them down into three main components:

```math
\epsilon_{p,q}^k = e^{\eta_{p,q}^k + i(\phi_{p,q}^k + 2\pi\tau_{p,q}\nu_k)}.
```

being an amplitude, phase, and the time-delay incurred by the pathlength between antennas. Again, in our vanilla data format these are simply stored as complex numbers wrt time and frequency, so the above parameterization is not strictly necessary, but it's useful to see how one can generally parameterize the coefficients (the amplitude and phase, in particular, could pick up time and frequency dependence in theory).

For multiple path coupling, the corrupted voltage vector gains additional factors of $X$,

```math
\tilde{v} = v + Xv + XXv + ...
```
We can probably truncate this at 2nd order, meaning that "double-path" coupling can be written as

```math
\tilde{V} = (I + X + XX)V(I + X + XX)^\dagger
```

If we produce an estimate the coupling matrix from the data (in many of the different ways we are imagining), which we will call $\hat{X}$, then we can invert the effects of coupling to produce an estimate of the intrinsic, uncorrupted visibilities as

```math
\hat{V} = \hat{E}^{-1} \tilde{V} \hat{E}^{-T}
```